### PR TITLE
Add glassmorphism styling to grid layouts

### DIFF
--- a/src/components/DraggableCatalogue.tsx
+++ b/src/components/DraggableCatalogue.tsx
@@ -141,7 +141,7 @@ function parseTextWithLineBreaks(text: string, keyOffset: number): (string | JSX
 function ProjectCard({ title, summary, tags, url }: any) {
   const isGithub = url?.includes("github.com");
   return (
-    <article className="h-full w-full rounded-xl border border-border bg-card shadow-soft overflow-hidden flex flex-col">
+    <article className="h-full w-full rounded-xl border border-border bg-card shadow-soft overflow-hidden flex flex-col glass-surface">
       <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 cursor-grab drag-handle">
         <div className="flex items-center gap-2">
           <GripVertical className="h-4 w-4 text-muted-foreground" />

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -29,7 +29,7 @@ export function LinkCard({
   return (
     <div
       className={[
-        "h-full select-none rounded-lg shadow-soft p-5 flex flex-col justify-center",
+        "h-full select-none rounded-lg shadow-soft p-5 flex flex-col justify-center glass-surface",
         borderClass,
         bgClass,
         className,

--- a/src/components/ThemeCycleCard.tsx
+++ b/src/components/ThemeCycleCard.tsx
@@ -9,7 +9,7 @@ export function ThemeCycleCard() {
     <button
       onClick={cycle}
       className="
-        w-full h-full rounded-lg
+        w-full h-full rounded-lg glass-surface
         border border-[hsl(var(--border))]
         bg-[hsl(var(--card))] text-[hsl(var(--foreground))]
         shadow-soft

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,23 @@
 html, body, #root { height: 100%; }
 body { @apply bg-background text-foreground; }
 
+.glass-surface {
+  position: relative;
+  isolation: isolate;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.glass-surface::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: inherit;
+  opacity: 0.82;
+  z-index: -1;
+  border-radius: inherit;
+}
+
 
 .react-grid-item.react-grid-placeholder {
   background:  hsl(var(--foreground)) none repeat scroll 0% 0% !important;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -139,7 +139,7 @@ export default function Home() {
           {/* empty on purpose */}
         </div>
 
-        <div key="block" className="rounded-lg bg-card shadow-soft p-6 flex flex-col">
+        <div key="block" className="rounded-lg bg-card shadow-soft p-6 flex flex-col glass-surface">
           <h1 className="text-3xl font-bold">Hello, I'm Marc Cruz!</h1>
           <h1 className="text-3xl font-bold mb-5">I develop & build software.</h1>
           
@@ -148,7 +148,7 @@ export default function Home() {
           </p>
         </div>
 
-        <div key="block-4" className="font-bold rounded-lg bg-card shadow-soft p-6 flex flex-col">
+        <div key="block-4" className="font-bold rounded-lg bg-card shadow-soft p-6 flex flex-col glass-surface">
 
           <p className="mb-4 no-drag">
             <i>Previously</i>
@@ -175,7 +175,7 @@ export default function Home() {
 
         </div>
 
-        <div key="block-3" className="rounded-lg bg-card shadow-soft p-6 flex flex-col">
+        <div key="block-3" className="rounded-lg bg-card shadow-soft p-6 flex flex-col glass-surface">
           <p className="text-sm mt-auto font-bold">Featured Projects</p>
           <br></br>
           <p className="text-xs">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea</p>
@@ -234,9 +234,9 @@ export default function Home() {
         <div
           key="block-2">
           <ThemeCycleCard></ThemeCycleCard>
-          </div>
+        </div>
 
-        <div key="hero" className="rounded-lg bg-card shadow-soft overflow-hidden">
+        <div key="hero" className="rounded-lg bg-card shadow-soft overflow-hidden glass-surface">
             <img
               alt="Marc Cruz"
               src={"/pfp.jpg"}
@@ -248,7 +248,7 @@ export default function Home() {
             />
         </div>
         
-        <div key="hero-2" className="rounded-lg bg-card shadow-soft flex">
+        <div key="hero-2" className="rounded-lg bg-card shadow-soft flex glass-surface">
           <img
             alt="White lotus flower"
             src={"/img2.JPG"}
@@ -260,7 +260,7 @@ export default function Home() {
           />
         </div>
 
-        <div key="hero-3" className="rounded-lg bg-card shadow-soft flex">
+        <div key="hero-3" className="rounded-lg bg-card shadow-soft flex glass-surface">
           <img
             alt="El Nido's Beach"
             src={"/img3.JPG"}

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -11,7 +11,7 @@ export default function Projects() {
       <ProjectsGraph
         items={projects}
         initialMode="groups"
-        className="border border-border rounded-lg bg-card shadow-soft p-4 responsive-graph" 
+        className="border border-border rounded-lg bg-card shadow-soft p-4 responsive-graph glass-surface"
       />
 
       <DraggableCatalogue />


### PR DESCRIPTION
## Summary
- add reusable glass-surface utility to create consistent glassmorphism styling
- apply glassmorphism to home page grid cards and project graph container while preserving theme colors
- update project catalogue cards to use the new glass effect

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692750bb79dc8330bebb738647e8c53a)